### PR TITLE
Bump Stripe SDK version to 14.0.2

### DIFF
--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '~> 14.0.1'
+  s.dependency 'Stripe', '~> 14.0.2'
 end


### PR DESCRIPTION
## Proposed changes
- Update Stripe SDK from `14.0.1` to `14.0.2`

## Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)  



